### PR TITLE
Use .zip files instead of .tar.gz files

### DIFF
--- a/nbzip/handlers.py
+++ b/nbzip/handlers.py
@@ -39,7 +39,7 @@ class ZipHandler(IPythonHandler):
             'attachment; filename=\"notebook-{}.zip\"'.format(zip_path)
         )
 
-        if zip_path == 'Home':
+        if zip_path == '':
             zip_path = '.'
 
         self.log.info('zipping')

--- a/nbzip/handlers.py
+++ b/nbzip/handlers.py
@@ -2,6 +2,7 @@ from tornado import gen, web
 from notebook.base.handlers import IPythonHandler
 
 import os
+import tarfile
 import zipfile
 
 
@@ -21,6 +22,15 @@ class ZipStream(object):
         self.handler.flush()
 
 
+def make_writer(fileobj, fmt):
+    if fmt == 'tar.gz':
+        return tarfile.open(fileobj=fileobj, mode='w:gz')
+
+    zip_file = zipfile.ZipFile(fileobj, mode='w')
+    zip_file.add = zip_file.write  # Patch API to match that of tarfile
+    return zip_file
+
+
 class ZipHandler(IPythonHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -30,13 +40,14 @@ class ZipHandler(IPythonHandler):
     def get(self):
         zip_path = self.get_argument('zipPath')
         zip_token = self.get_argument('zipToken')
+        fmt = self.get_argument('format', 'zip')
 
         # We gonna send out event streams!
         self.set_header('content-type', 'application/octet-stream')
         self.set_header('cache-control', 'no-cache')
         self.set_header(
             'content-disposition',
-            'attachment; filename=\"notebook-{}.zip\"'.format(zip_path)
+            'attachment; filename=\"{}.{}\"'.format(zip_path or 'home', fmt)
         )
 
         if zip_path == '':
@@ -45,12 +56,12 @@ class ZipHandler(IPythonHandler):
         self.log.info('zipping')
 
         file_name = None
-        with zipfile.ZipFile(ZipStream(self), mode='w') as zf:
+        with make_writer(ZipStream(self), fmt) as zf:
             for root, dirs, files in os.walk(zip_path):
-                for file in files:
-                    file_name = os.path.join(root, file)
+                for file_ in files:
+                    file_name = os.path.join(root, file_)
                     self.log.info("{}\n".format(file_name))
-                    zf.write(file_name, arcname=os.path.join(root[len(zip_path):], file))
+                    zf.add(file_name, os.path.join(root[len(zip_path):], file_))
 
         self.set_cookie("zipToken", zip_token)
         self.log.info('Finished zipping')

--- a/nbzip/static/tree.js
+++ b/nbzip/static/tree.js
@@ -19,7 +19,7 @@ define([
     }
 
     expireCookie = function ( cName ) {
-        document.cookie = 
+        document.cookie =
             encodeURIComponent(cName) + "=deleted; expires=" + new Date( 0 ).toUTCString();
     }
 
@@ -31,11 +31,11 @@ define([
           $('<div>').addClass('btn-group').attr('id', 'nbzip-link').prepend(
                '<button class="btn btn-xs btn-default" title="Zip Notebook"><i class="fa-download fa"></i></button>'
           ).click(function() {
-            baseUrl = document.location.origin;
-            zipPath = document.title.replace(/\/$/, ''); // get rid of trailing slash.
+            baseUrl = document.location.origin + document.body.getAttribute('data-base-url');
+            zipPath = document.body.getAttribute('data-notebook-path');
             currToken = newToken();
 
-            window.location.href = baseUrl + '/zip-download?zipPath=' + zipPath + '&zipToken=' + currToken;
+            window.location.href = baseUrl + 'zip-download?zipPath=' + zipPath + '&zipToken=' + currToken;
             $("#nbzip-link").html("Zipping...");
 
             tid = setInterval(function() {

--- a/nbzip/static/tree.js
+++ b/nbzip/static/tree.js
@@ -31,7 +31,7 @@ define([
           $('<div>').addClass('btn-group').attr('id', 'nbzip-link').prepend(
                '<button class="btn btn-xs btn-default" title="Zip Notebook"><i class="fa-download fa"></i></button>'
           ).click(function() {
-            baseUrl = document.origin;
+            baseUrl = document.location.origin;
             zipPath = document.title.replace(/\/$/, ''); // get rid of trailing slash.
             currToken = newToken();
 

--- a/tests/test_nbzip.py
+++ b/tests/test_nbzip.py
@@ -1,12 +1,13 @@
 from notebook.notebookapp import list_running_servers
 import subprocess
+import io
 import os
 import time
 import logging
 import json
 import shutil
 import urllib.request
-import tarfile
+import zipfile
 
 
 TIMEOUT = 10  # in seconds
@@ -73,9 +74,9 @@ def create_test_files(test_dir_name):
 def unzip_zipped_file(dir_name, download_path, token):
     if os.path.exists(dir_name):
         shutil.rmtree(dir_name)
-    tar_file = tarfile.open(fileobj=download_zip_file(download_path, token), mode='r:gz')
-    tar_file.extractall(dir_name)
-    tar_file.close()
+    zip_file = zipfile.ZipFile(download_zip_file(download_path, token), mode='r')
+    zip_file.extractall(dir_name)
+    zip_file.close()
 
 
 def check_zipped_file_contents(env_dir, download_path, token):
@@ -110,7 +111,7 @@ def download_zip_file(download_path, token):
             'Authorization': 'Token {}'.format(token)
         }
     )
-    return urllib.request.urlopen(req)
+    return io.BytesIO(urllib.request.urlopen(req).read())
 
 
 def test_zip():

--- a/tests/test_nbzip.py
+++ b/tests/test_nbzip.py
@@ -11,6 +11,7 @@ import zipfile
 
 
 TIMEOUT = 10  # in seconds
+PORT = 18888
 logging.getLogger().setLevel(logging.INFO)
 
 
@@ -32,7 +33,7 @@ def run_and_return(cmd):
 def wait_for_notebook_to_start():
     wait_time = 0
     logging.info("waiting for notebook to start...")
-    while ("localhost:8888" not in run_and_return("jupyter notebook list")):
+    while ("localhost:{}".format(PORT) not in run_and_return("jupyter notebook list")):
         if (wait_time >= TIMEOUT):
             logging.info("Test timed out...")
             return False
@@ -106,7 +107,7 @@ def get_all_file_contents(dir):
 
 def download_zip_file(download_path, token):
     req = urllib.request.Request(
-        "http://localhost:8888/zip-download?zipPath={}&zipToken=1".format(download_path),
+        "http://localhost:{}/zip-download?zipPath={}&zipToken=1".format(PORT, download_path),
         headers={
             'Authorization': 'Token {}'.format(token)
         }
@@ -121,10 +122,10 @@ def test_zip():
     env_dir = 'testenv'
     create_test_files(env_dir)
 
-    os.system("jupyter-notebook --port=8888 --no-browser &")
+    os.system("jupyter-notebook --port={} --no-browser &".format(PORT))
 
     if (not wait_for_notebook_to_start()):
-        return
+        assert False, "Notebook server failed to start"
 
     server = next(list_running_servers())
     token = server['token']
@@ -137,4 +138,4 @@ def test_zip():
         check_zipped_file_contents(env_dir, 'dir/4', token)
     finally:
         logging.info("Shutting down notebook server...")
-        os.system("jupyter notebook stop 8888")
+        os.system("jupyter notebook stop {}".format(PORT))


### PR DESCRIPTION
I don't know if you're interested in this change or not, but in my experience, people are more familiar with zipfiles than tarfiles.  The changes are pretty minimal, so we could imagine keeping both and making the format a configuration option, but that struck me as more trouble than it was worth.  If you'd like it, let me know.

This is built atop #11, for no reason other than that I stumbled across that while working on this.