### PR TITLE
URI-decode the base URL before assembling URL for zip download

### DIFF
--- a/nbzip/static/tree.js
+++ b/nbzip/static/tree.js
@@ -31,7 +31,7 @@ define([
           $('<div>').addClass('btn-group').attr('id', 'nbzip-ziplink').prepend(
                '<button class="btn btn-xs btn-default" title="Download as ZIP"><i class="fa-download fa"></i></button>'
           ).click(function() {
-            baseUrl = document.location.origin + document.body.getAttribute('data-base-url');
+            baseUrl = document.location.origin + decodeURIComponent(document.body.getAttribute('data-base-url'));
             zipPath = document.body.getAttribute('data-notebook-path');
             currToken = newToken();
 


### PR DESCRIPTION
I didn't think this should be necessary, but I needed it to get downloads working for users with odd characters in their usernames on a JupyterHub-on-k8s install.

In my testing, this work for usernames containing an `@` (which is where I noticed the problem) and an `%` (which would seem like a tough one to get right).  Let me know if there are any other characters we ought to test.